### PR TITLE
removed missing libraries from build path

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -23,15 +23,6 @@
 	<classpathentry kind="lib" path="thirdparty/mysql-connector-java-5.1.14/mysql-connector-java-5.1.14-bin.jar"/>
 	<classpathentry kind="lib" path="thirdparty/commons-pool-1.5.6/commons-pool-1.5.6.jar"/>
 	<classpathentry kind="lib" path="thirdparty/jedis/target/jedis-1.5.3-SNAPSHOT.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/commons-httpclient/commons-logging-1.1.1.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/commons-httpclient/httpclient-4.1-alpha2.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/commons-httpclient/httpclient-cache-4.1-alpha2.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/commons-httpclient/httpcore-4.1-beta1.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/commons-httpclient/httpmime-4.1-alpha2.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/lib/commons-codec-1.4.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/lib/jdom.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/lib/log4j-1.2.15.jar"/>
-	<classpathentry kind="lib" path="thirdparty/atmos/lib/security-1.1.jar"/>
 	<classpathentry kind="lib" path="thirdparty/jets3t-0.8.1/jars/jets3t-0.8.1.jar" sourcepath="thirdparty/jets3t-0.8.1/src.zip">
 		<attributes>
 			<attribute name="javadoc_location" value="jar:platform:/resource/rain/thirdparty/jets3t-0.8.1/api-docs.zip!/"/>
@@ -40,21 +31,7 @@
 	<classpathentry kind="lib" path="thirdparty/jets3t-0.8.1/libs/commons-codec/commons-codec-1.3.jar"/>
 	<classpathentry kind="lib" path="thirdparty/jets3t-0.8.1/libs/commons-httpclient/commons-httpclient-3.1.jar"/>
 	<classpathentry kind="lib" path="thirdparty/jets3t-0.8.1/libs/commons-logging/commons-logging-1.1.1.jar"/>
-	<classpathentry kind="lib" path="thirdparty/jets3t-0.8.1/libs/java-xmlbuilder/java-xmlbuilder-0.4.jar"/>
 	<classpathentry kind="lib" path="thirdparty/mongo-2.5.3/mongo-2.5.3.jar" sourcepath="/home/rean/work/rain.git/thirdparty/mongo-2.5.3/mongo-2.5.3.zip"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/cassandra-thrift-1.0.0.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/commons-lang-2.4.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/commons-pool-1.5.3.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/FastInfoset-1.2.2.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/guava-r09.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/hector-core-1.0-1-sources.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/hector-core-1.0-1-tests.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/hector-core-1.0-1.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/libthrift-0.6.1.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/slf4j-api-1.6.1.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/speed4j-0.9.jar"/>
-	<classpathentry kind="lib" path="thirdparty/hector-core-1.0-1/uuid-3.2.0.jar"/>
-	<classpathentry kind="lib" path="thirdparty/commons-math-2.2/commons-math-2.2.jar"/>
 	<classpathentry kind="lib" path="thirdparty/riak-java-client/target/riak-client-1.0.6-SNAPSHOT-jar-with-dependencies.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
After I imported the rain-workload-toolkit in eclipse via File -> Import -> Existing Project... there are 24 errors in the project due to missing libraries in the build path. I updated the .classpath file by removing the missing libraries.
