### PR TITLE
Make sure HTTP redirect locations are absolute

### DIFF
--- a/src/radlab/rain/util/HttpTransport.java
+++ b/src/radlab/rain/util/HttpTransport.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
+import java.net.URI;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -663,7 +664,25 @@ public class HttpTransport
 					{
 						start = System.currentTimeMillis();
 						// TODO: Is it safe to assume all redirects are GET requests?
-						httpRequest = new HttpGet( locationHeaders[0].getValue() );
+						//httpRequest = new HttpGet( locationHeaders[0].getValue() );
+						URI redirURI = null;
+						try
+						{
+							redirURI = new URI(locationHeaders[0].getValue());
+							if (!redirURI.isAbsolute())
+							{
+								redirURI = httpRequest.getURI().resolve(redirURI);
+							}
+							httpRequest = new HttpGet(redirURI.toString());
+						}
+						catch (Throwable t)
+						{
+							if (this._debug)
+							{
+								System.out.println("Unable to create URI from redirect location: " + locationHeaders[0].getValue() + " (" + t + "). Try to use redirect location directly.");
+							}
+							httpRequest = new HttpGet(locationHeaders[0].getValue());
+						}
 						end = System.currentTimeMillis();
 						if( this._debug )
 							System.out.println( "HttpClient request get redirect: " + httpRequest.getRequestLine() + " (" +  (end - start)/1000.0 + ")" );


### PR DESCRIPTION
This is a minor bug-fix in order to make sure that HTTP redirect locations (i.e., URIs from the "Location" HTTP header) are absolute.
The code check for absolute URIs by means of java.net.URI.
In case of a relative URI,  and i, and if not, try to make them absolute by resolving them against the URI of the current request (see line 674).

Please, consider to merge this change.

Best,

-- Marco
