### PR TITLE
'resourcePath' configuration key is not parsed.

### DIFF
--- a/src/radlab/rain/ScenarioTrack.java
+++ b/src/radlab/rain/ScenarioTrack.java
@@ -386,6 +386,11 @@ public abstract class ScenarioTrack
 			this._loadGenerationStrategyClassName = ScenarioTrack.DEFAULT_LOAD_GENERATION_STRATEGY_CLASS;
 			this._loadGenerationStrategyParams = new JSONObject();
 		}
+		// 15 Look for a resource path
+		if (config.has(ScenarioTrack.CFG_RESOURCE_PATH))
+		{
+			this._resourcePath = config.getString(ScenarioTrack.CFG_RESOURCE_PATH);
+		}
 	}
 	
 	// Factory methods


### PR DESCRIPTION
This is a minor bug-fix in order to parse the 'resourcePath' configuration parameter (since it was missing).

Please, consider to merge this change.

Best,

-- Marco
