### PR TITLE
Added new constructors to statistics-related utility classes that accept a java.util.Random object

### DIFF
--- a/src/radlab/rain/util/CDF.java
+++ b/src/radlab/rain/util/CDF.java
@@ -113,6 +113,40 @@ public class CDF<T>
 		this.normalize();
 	}
 	
+	@SuppressWarnings("unchecked")
+	public CDF( Random rng, JSONArray labels, JSONArray counts ) throws JSONException
+	{
+		this._random = rng;
+		this._rawCounts = new long[counts.length()];
+		this._cdf = new double[counts.length()];
+		
+		this._sum = 0.0;
+		for( int i = 0; i < counts.length(); i++ )
+		{
+			this._labels.add( (T) labels.get(i) );
+			this._rawCounts[i] = counts.getLong(i);
+			this._sum += counts.getDouble(i);
+			this._cdf[i] = this._sum;
+		}
+		this.normalize();
+	}
+	
+	public CDF( Random rng, T[] labels, double[] counts )
+	{
+		this._random = rng;
+		this._rawCounts = new long[counts.length];
+		this._cdf = new double[counts.length];
+		this._sum = 0.0;
+		for( int i = 0; i < counts.length; i++ )
+		{
+			this._labels.add( (T) labels[i] );
+			this._rawCounts[i] = new Double(counts[i]).longValue();
+			this._sum += counts[i];
+			this._cdf[i] = this._sum;
+		}
+		this.normalize();
+	}
+	
 	public void normalize()
 	{
 		double sum = this._cdf[this._cdf.length-1];

--- a/src/radlab/rain/util/EmpiricalCDF.java
+++ b/src/radlab/rain/util/EmpiricalCDF.java
@@ -39,16 +39,30 @@ public class EmpiricalCDF
 	// <cdf summary> = [<pctilemark,value>,...,<pctilemark,value>]
 	private TreeMap<Double,Double> _cdfSummary = null;
 	private double[] _rawCdf = null;
-	private Random _random = new Random();
+	private Random _random;
 	
 	public EmpiricalCDF( double[] rawCdf )
 	{
 		this._rawCdf = rawCdf;
+		this._random = new Random();
 	}
 	
 	public EmpiricalCDF( TreeMap<Double,Double> cdfSummary )
 	{
 		this._cdfSummary = cdfSummary;
+		this._random = new Random();
+	}
+	
+	public EmpiricalCDF( double[] rawCdf, Random rng )
+	{
+		this._rawCdf = rawCdf;
+		this._random = rng;
+	}
+	
+	public EmpiricalCDF( TreeMap<Double,Double> cdfSummary, Random rng )
+	{
+		this._cdfSummary = cdfSummary;
+		this._random = rng;
 	}
 	
 	public double nextDouble()

--- a/src/radlab/rain/util/NegativeExponential.java
+++ b/src/radlab/rain/util/NegativeExponential.java
@@ -35,12 +35,19 @@ import java.util.Random;
 
 public class NegativeExponential 
 {
-	private Random _random = new Random();
+	private Random _random;
 	private double _mean = 0.0;
 	
 	public NegativeExponential( double mean )
 	{
 		this._mean = mean;
+		this._random = new Random();
+	}
+	
+	public NegativeExponential( double mean, Random rng )
+	{
+		this._mean = mean;
+		this._random = rng;
 	}
 	
 	// Courtesy: http://www.sitmo.com/eq/513 - Generating an Exponential distributed random number

--- a/src/radlab/rain/util/Pareto.java
+++ b/src/radlab/rain/util/Pareto.java
@@ -37,12 +37,20 @@ public class Pareto
 {
 	private double _alpha = 0.0;
 	private double _beta = 0.0;
-	private Random _random = new Random();
+	private Random _random;
 	
 	public Pareto( double alpha, double beta )
 	{
 		this._alpha = alpha;
 		this._beta = beta;
+		this._random = new Random();
+	}
+	
+	public Pareto( double alpha, double beta, Random rng )
+	{
+		this._alpha = alpha;
+		this._beta = beta;
+		this._random = rng;
 	}
 	
 	// Courtesy: http://www.sitmo.com/eq/521 - Generating Pareto distributed random number

--- a/src/radlab/rain/util/ParetoBounded.java
+++ b/src/radlab/rain/util/ParetoBounded.java
@@ -38,13 +38,22 @@ public class ParetoBounded
 	private double _alpha = 0.0;
 	private double _lowerBound = 0.0;
 	private double _upperBound = 0.0;
-	private Random _random = new Random();
+	private Random _random;
 	
 	public ParetoBounded( double alpha, double L, double H )
 	{
 		this._alpha = alpha;
 		this._lowerBound = L;
 		this._upperBound = H;
+		this._random = new Random();
+	}
+
+	public ParetoBounded( double alpha, double L, double H, Random rng )
+	{
+		this._alpha = alpha;
+		this._lowerBound = L;
+		this._upperBound = H;
+		this._random = rng;
 	}
 
 	// Courtesy: http://en.wikipedia.org/wiki/Pareto_distribution

--- a/src/radlab/rain/util/PoissonSamplingStrategy.java
+++ b/src/radlab/rain/util/PoissonSamplingStrategy.java
@@ -33,6 +33,7 @@ package radlab.rain.util;
 
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.Random;
 
 public class PoissonSamplingStrategy implements ISamplingStrategy
 {
@@ -58,6 +59,13 @@ public class PoissonSamplingStrategy implements ISamplingStrategy
 	{
 		this._meanSamplingInterval = meanSamplingInterval;
 		this._expRandom = new NegativeExponential(this._meanSamplingInterval);
+		this.reset();
+	}
+
+	public PoissonSamplingStrategy(double meanSamplingInterval, Random rng) 
+	{
+		this._meanSamplingInterval = meanSamplingInterval;
+		this._expRandom = new NegativeExponential(this._meanSamplingInterval, rng);
 		this.reset();
 	}
 

--- a/src/radlab/rain/util/Zipf.java
+++ b/src/radlab/rain/util/Zipf.java
@@ -39,7 +39,7 @@ public class Zipf
 	long _upperBound = 0;
 	double _a = 0.0;
 	double _r = 0.0;
-	private Random _random = new Random();
+	private Random _random;
 	
 	private boolean _first = true;
 	private double _c = 0; // Normalization constant
@@ -50,6 +50,16 @@ public class Zipf
 		this._r = r;
 		this._lowerBound = L;
 		this._upperBound = H + 1;
+		this._random = new Random();
+	}
+	
+	public Zipf( double a, double r, long L, long H, Random rng )
+	{
+		this._a = a;
+		this._r = r;
+		this._lowerBound = L;
+		this._upperBound = H + 1;
+		this._random = rng;
 	}
 	
 	public double nextDouble2()


### PR DESCRIPTION
Hello,

I've added new constructors to some statistics-related classes under the `radlab.rain.util` package that accept a `java.util.Random` object.
The rationale for this change is to enable the reuse of an already created random number generator and thus to help experiment's reproducibility (i.e., to reproduce experiments with the same random number sequence starting from the same seed).

Please, consider to merge this commit.

Best,

-- Marco
