### PR TITLE
[core] Load configuration files from file system first, then as resource

### DIFF
--- a/src/radlab/rain/Benchmark.java
+++ b/src/radlab/rain/Benchmark.java
@@ -32,6 +32,7 @@
 package radlab.rain;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -308,22 +309,29 @@ public class Benchmark
 		try
 		{
 			String fileContents = "";
-			// Try to load the config file as a resource first
-			InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream( filename );
-			if( in != null )
-			{
-				System.out.println( "[BENCHMARK] Reading config file from resource stream." );
-				BufferedReader reader = new BufferedReader( new InputStreamReader( in ) );
-				String line = "";
-				// Read in the entire file and append to the string buffer
-				while( ( line = reader.readLine() ) != null )
-					configData.append( line );
-				fileContents = configData.toString();
-			}
-			else
+			if (new File(filename).exists())
 			{
 				System.out.println( "[BENCHMARK] Reading config file from file system." );
 				fileContents = ConfigUtil.readFileAsString( filename );
+			}
+			else
+			{
+				// Try to load the config file as a resource first
+				InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream( filename );
+				if( in != null )
+				{
+					System.out.println( "[BENCHMARK] Reading config file from resource stream." );
+					BufferedReader reader = new BufferedReader( new InputStreamReader( in ) );
+					String line = "";
+					// Read in the entire file and append to the string buffer
+					while( ( line = reader.readLine() ) != null )
+						configData.append( line );
+					fileContents = configData.toString();
+				}
+				else
+				{
+					throw new IOException("Config file not found");
+				}
 			}
 			
 			jsonConfig = new JSONObject( fileContents );


### PR DESCRIPTION
Hello,

Currently, in RAIN the configuration file (passed as command line argument) is first loaded as a resource

```
ClassLoader.getSystemClassLoader().getResourceAsStream
```

and, if not found, it is loaded from the file system

```
ConfigUtil.readFileAsString
```

With this patch, I suggest to invert the priority, that is I suggest to give higher priority to the configuration file stored in the file system.

The rationale for this is that the JAR always store its configuration files.
However, such files are the ones you have at _compilation time_.
If you want to change your configuration _after_ compilation time (e.g., you want to experiment with different traffic mix, or with different number of users), currently you have no way but to change the configuration file and the recompile.
Instead, if we give higher priority to configuration files stored in the file system, we can avoid the recompilation step.
Just change the configuration file, and run RAIN.

Thus, this patch makes RAIN to first load configuration from file system, and then from the resources.

Please, consider to merge this patch.

Best,

-- Marco
