### PR TITLE
Cassandra workload: Fixed implementation of 'getThinkTime()' and 'getCycleTime()'

### DIFF
--- a/src/radlab/rain/workload/cassandra/CassandraGenerator.java
+++ b/src/radlab/rain/workload/cassandra/CassandraGenerator.java
@@ -182,7 +182,7 @@ public class CassandraGenerator extends Generator
 	
 	
 	@Override
-	public long getThinkTime() 
+	public long getCycleTime() 
 	{
 		if (this._cycleTime <= 0)
 		{
@@ -193,7 +193,7 @@ public class CassandraGenerator extends Generator
 	}
 
 	@Override
-	public long getCycleTime() 
+	public long getThinkTime() 
 	{
 		if (this._thinkTime <= 0)
 		{


### PR DESCRIPTION
Hi,

I've mistakenly exchanged the implementation of `getThinkTime()` with that of `getCycleTime()`.
This pull request fix this issue.

Can you merge it?

Thanks,

-- Marco
